### PR TITLE
# Fix AddFilesToCollectionResponseSchema to Match API Behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@needle-ai/needle",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "This Typescript library provides convenient access to the Needle API.",
   "homepage": "https://github.com/oeken/needle-typescript",
   "bugs": {

--- a/src/v1/collections/models.ts
+++ b/src/v1/collections/models.ts
@@ -71,7 +71,6 @@ export type AddFilesToCollectionRequest = z.infer<
 export const AddFilesToCollectionResponseSchema = z.object({
   result: z.array(
     z.object({
-      // Required, non-null fields
       id: z.string(),
       name: z.string(),
       type: z.string(),
@@ -79,13 +78,9 @@ export const AddFilesToCollectionResponseSchema = z.object({
       created_at: z.string(),
       user_id: z.string(),
       url: z.string().url(),
-
-      // Nullable fields that API includes with null values
       size: z.number().nullable(),
       md5_hash: z.string().nullable(),
       connector_id: z.string().nullable(),
-
-      // Nullable fields that API might omit entirely
       error: z.string().nullable().optional(),
       connector: ConnectorSchema.nullable().optional(),
     }),

--- a/src/v1/collections/models.ts
+++ b/src/v1/collections/models.ts
@@ -82,7 +82,7 @@ export const AddFilesToCollectionResponseSchema = z.object({
       md5_hash: z.string().nullable(),
       connector_id: z.string().nullable(),
       error: z.string().nullish(),
-      connector: ConnectorSchema..nullish(),
+      connector: ConnectorSchema.nullish(),
     }),
   ),
 });

--- a/src/v1/collections/models.ts
+++ b/src/v1/collections/models.ts
@@ -81,8 +81,8 @@ export const AddFilesToCollectionResponseSchema = z.object({
       size: z.number().nullable(),
       md5_hash: z.string().nullable(),
       connector_id: z.string().nullable(),
-      error: z.string().nullable().optional(),
-      connector: ConnectorSchema.nullable().optional(),
+      error: z.string().nullish(),
+      connector: ConnectorSchema..nullish(),
     }),
   ),
 });

--- a/src/v1/collections/models.ts
+++ b/src/v1/collections/models.ts
@@ -71,18 +71,23 @@ export type AddFilesToCollectionRequest = z.infer<
 export const AddFilesToCollectionResponseSchema = z.object({
   result: z.array(
     z.object({
+      // Required, non-null fields
       id: z.string(),
       name: z.string(),
       type: z.string(),
       status: z.enum(["pending", "indexed", "error"]),
-      error: z.string().nullable(),
       created_at: z.string(),
       user_id: z.string(),
       url: z.string().url(),
+
+      // Nullable fields that API includes with null values
       size: z.number().nullable(),
       md5_hash: z.string().nullable(),
       connector_id: z.string().nullable(),
-      connector: ConnectorSchema.nullable(),
+
+      // Nullable fields that API might omit entirely
+      error: z.string().nullable().optional(),
+      connector: ConnectorSchema.nullable().optional(),
     }),
   ),
 });


### PR DESCRIPTION
## Issue
The current schema assumes all nullable fields must be present in the API response (even if null), but the actual API behavior is inconsistent:
- Some nullable fields are included with null values (`size`, `connector_id`, `md5_hash`)
- Other nullable fields are omitted entirely (`error`, `connector`)

This mismatch causes validation errors when using the SDK.

## Changes
Updated `AddFilesToCollectionResponseSchema` to:
- Keep required fields as-is
- Keep fields that API includes with null values as just `.nullable()`
- Add `.optional()` to fields that API might omit entirely

## API Documentation Note
There appears to be an inconsistency in the API documentation where "nullable" is used to describe two different behaviors:
1. Fields that must be present but can be null
2. Fields that can be omitted entirely

We should consider updating the API documentation to be more precise about:
- Required fields (always present, never null)
- Nullable fields (always present, can be null)
- Optional/Omitable fields (might not be present at all)